### PR TITLE
Variable DOMAIN por defecto

### DIFF
--- a/+config/config.php
+++ b/+config/config.php
@@ -63,7 +63,7 @@ if (!defined('PAIS'))
 
 
 // CONFIG
-define('DOMAIN', getenv("DOMAIN"));
+define('DOMAIN', getenv("DOMAIN") ?: 'virtualpol.com');
 define('CONTACTO_EMAIL', 'desarollo@virtualpol.com');
 
 define('SQL', strtolower(PAIS).'_');


### PR DESCRIPTION
Soluciona lo comentado en el issue #243 y otros enlaces rotos en la plataforma.

Esto soluciona el error del dominio 'pol.' en los correos, pero se debe a que la variable de entorno DOMAIN parece que no existe en el servidor. De igual manera se agrega en el codigo la validacion de esa variable y valor por defecto.

@JavierGonzalez puedes revisar las variables de todas formas?

fix #243 
